### PR TITLE
Fix: hiding other folders on scroll

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,7 @@ export default class HideFoldersPlugin extends Plugin {
 
     if(recheckPreviouslyHiddenFolders) {
       document.querySelectorAll(".obsidian-hide-folders--hidden").forEach((folder) => {
-        folder.parentElement!.style.display = "";
+        folder.parentElement!.style.cssText = "";
         folder.removeClass("obsidian-hide-folders--hidden");
       });
     }
@@ -39,7 +39,7 @@ export default class HideFoldersPlugin extends Plugin {
         }
 
         folder.addClass("obsidian-hide-folders--hidden");
-        folder.parentElement.style.display = this.settings.areFoldersHidden ? "none" : "";
+        folder.parentElement.style.cssText = this.settings.areFoldersHidden ? "height: 0;overflow: hidden;" : "";
       });
     });
   }

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,8 @@ export default class HideFoldersPlugin extends Plugin {
 
     if(recheckPreviouslyHiddenFolders) {
       document.querySelectorAll(".obsidian-hide-folders--hidden").forEach((folder) => {
-        folder.parentElement!.style.cssText = "";
+        folder.parentElement!.style.height = "";
+        folder.parentElement!.style.overflow = "";
         folder.removeClass("obsidian-hide-folders--hidden");
       });
     }
@@ -39,7 +40,8 @@ export default class HideFoldersPlugin extends Plugin {
         }
 
         folder.addClass("obsidian-hide-folders--hidden");
-        folder.parentElement.style.cssText = this.settings.areFoldersHidden ? "height: 0;overflow: hidden;" : "";
+        folder.parentElement.style.height = this.settings.areFoldersHidden ? "0" : "";
+        folder.parentElement.style.overflow = this.settings.areFoldersHidden ? "hidden" : "";
       });
     });
   }


### PR DESCRIPTION
Fixed the hiding of other folders unrelated to the one configured to be removed by the plugin, see the bug and the solution I took for it [in this video](https://www.youtube.com/watch?v=5CLOet38YGc)

This bug is related to the styling applied to hide the folder in the DOM, specifically in the `display: none;` tag applied to hide it. The solution to this problem was to change `display: none;` to `height: 0;overflow: hidden;`.