### PR TITLE
fix for #11

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -171,7 +171,9 @@ export default class HideFoldersPlugin extends Plugin {
 
     this.app.workspace.onLayoutReady(() => {
       if(!this.settings.areFoldersHidden) return;
-      this.processFolders();
+      window.setTimeout(() => {
+        this.processFolders();
+      }, 1000);
     });
   }
 


### PR DESCRIPTION
Even with `onLayoutReady()` it wasn't enough, I guess in my case it was Omnisearch taking a long time to start up, before the File Explorer was rendered. Feels like a bug in Obsidian since `onLayoutReady` really should not fire until, well, it's ready...

But, adding a 1s delay here "fixes" the issue. If 1s is not enough, maybe we'll need to make the delay configurable in the settings panel.
