### PR TITLE
update mutationObserver with debounce and detection of multiple classes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import {App, Plugin, PluginSettingTab, setIcon, Setting} from "obsidian";
+import {App, Plugin, PluginSettingTab, setIcon, Setting, debounce} from "obsidian";
 import {CompatQuickExplorer} from "./compat/compat-quickexplorer";
 
 export interface HideFoldersPluginSettings {
@@ -22,10 +22,10 @@ const DEFAULT_SETTINGS: HideFoldersPluginSettings = {
 export default class HideFoldersPlugin extends Plugin {
   settings: HideFoldersPluginSettings;
   ribbonIconButton: HTMLElement;
-  statusBarItem: HTMLElement;
+  statusBarItem?: HTMLElement;
   mutationObserver: MutationObserver;
 
-  async processFolders(recheckPreviouslyHiddenFolders?: boolean) {
+  private processFolders = debounce(async (recheckPreviouslyHiddenFolders?: boolean) => {
     if(this.settings.attachmentFolderNames.length === 0) return;
 
     if(recheckPreviouslyHiddenFolders) {
@@ -55,7 +55,7 @@ export default class HideFoldersPlugin extends Plugin {
         folder.style.overflow = this.settings.areFoldersHidden ? "hidden" : "";
       });
     });
-  }
+  }, 10, false);
 
   getQuerySelectorStringForFolderName(folderName: string) {
     if(folderName.toLowerCase().startsWith("endswith::")) {
@@ -158,18 +158,21 @@ export default class HideFoldersPlugin extends Plugin {
 
     // used for re-processing folders when a folder is expanded in the file-navigator
     this.mutationObserver = new MutationObserver((mutationRecord) => {
-      mutationRecord.forEach(record => {
-        if(record.target?.parentElement?.classList.contains("nav-folder")) {
-          this.processFolders();
-          return;
-        }
+      const feClasses = [
+        "nav-folder",
+        "nav-files-container",
+      ];
 
-        if(this.settings.enableCompatQuickExplorer) {
-          if(CompatQuickExplorer.shouldMutationRecordTriggerFolderReProcessing?.(record)) {
-            this.processFolders();
-          }
-        }
+      // check if any of the mutationRecords fulfills the conditions for us to call processFolders
+      const shouldTriggerProcessFolders = mutationRecord.some((record) => {
+        if(feClasses.some(c => record.target?.parentElement?.classList.contains(c))) return true;
+        if(this.settings.enableCompatQuickExplorer && CompatQuickExplorer.shouldMutationRecordTriggerFolderReProcessing?.(record)) return true;
+
+        return false;
       });
+
+      if(!shouldTriggerProcessFolders) return;
+      this.processFolders();
     });
     this.mutationObserver.observe(window.document, {childList: true, subtree: true});
 
@@ -279,6 +282,7 @@ class HideFoldersPluginSettingTab extends PluginSettingTab {
           this.plugin.settings.hideBottomStatusBarIndicatorText = value;
           if(value) {
             this.plugin.statusBarItem?.remove();
+            this.plugin.statusBarItem = undefined;
           } else {
             this.plugin.createBottomStatusBarIndicatorTextItem();
           }


### PR DESCRIPTION
Companion fix for https://github.com/JonasDoesThings/obsidian-hide-folders/issues/11 (this seems better than previous proposed fix from #15)

Adds a 100ms delay around mutationObserver, and changes the detection class from `nav-folder` to `nav-files-container` which seems to be correct (on my system, `nav-folder` was not present)
